### PR TITLE
Enhance leaderboard podium design with crown avatars

### DIFF
--- a/leaderboard.html
+++ b/leaderboard.html
@@ -144,11 +144,30 @@
       .rail-active{ position:absolute; left:0; height:36px; border-top-right-radius:9999px; border-bottom-right-radius:9999px; background: linear-gradient(180deg, #3b82f6, #ec4899); box-shadow: 0 0 18px rgba(59,130,246,.6); top: 72px; transition: top .25s ease, height .2s ease, opacity .2s ease; }
 
       /* Podium */
-      .podium-col { position: relative; }
-      .podium-step { position: relative; border-radius: 18px; }
+      .podium-col { position: relative; perspective: 800px; }
+      .podium-col::after{
+        content:""; position:absolute; left:50%; bottom:-10px; width:70%; height:20px;
+        transform:translateX(-50%);
+        background:radial-gradient(ellipse at center, rgba(0,0,0,.5), transparent);
+        filter:blur(8px);
+      }
+      .podium-step {
+        position: relative; border-radius: 18px;
+        background: linear-gradient(145deg, rgba(255,255,255,.08), rgba(0,0,0,.3));
+        box-shadow: inset 0 2px 4px rgba(255,255,255,.1), inset 0 -4px 6px rgba(0,0,0,.4), 0 12px 20px rgba(0,0,0,.7);
+        transform: rotateX(15deg);
+      }
+      .podium-step::before{
+        content:""; position:absolute; inset:0; border-radius:inherit;
+        background:radial-gradient(circle at 50% 0, rgba(255,255,255,.25), transparent 70%);
+        pointer-events:none;
+      }
       .podium-1 { height: 220px; }
       .podium-2 { height: 170px; }
       .podium-3 { height: 140px; }
+
+      .podium-avatar{ width:48px; height:48px; border-radius:9999px; object-fit:cover; box-shadow:0 4px 8px rgba(0,0,0,.6),0 0 8px rgba(255,215,0,.6); }
+      .row-avatar{ width:32px; height:32px; border-radius:12px; object-fit:cover; box-shadow:0 2px 4px rgba(0,0,0,.5); }
 
       /* Count-down digits */
       .flip { font-variant-numeric: tabular-nums; letter-spacing: .5px; }
@@ -225,45 +244,30 @@
           <div class="mt-10 grid md:grid-cols-3 gap-6 items-end">
             <!-- 2nd -->
             <div class="podium-col">
-              <div class="glass podium-step podium-2 p-4 flex flex-col justify-end">
-                <div class="flex items-center gap-3">
-                  <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-indigo to-violet grid place-items-center"><i data-lucide="medal" class="w-5 h-5"></i></div>
-                  <div>
-                    <div class="text-sm text-white/60">#2</div>
-                    <div class="font-semibold truncate" id="p2-name">—</div>
-                  </div>
-                </div>
+              <div class="glass podium-step podium-2 p-4 flex flex-col items-center justify-end text-center">
+                <img src="crown.png" alt="profile" class="podium-avatar mb-2">
+                <div class="text-sm text-white/60">#2</div>
+                <div class="font-semibold truncate" id="p2-name">—</div>
                 <div class="mt-3 text-sm text-white/70" id="p2-wager">$0</div>
                 <div class="mt-1 text-xs text-white/50">Prize <span id="p2-prize">$0</span></div>
               </div>
             </div>
             <!-- 1st -->
             <div class="podium-col">
-              <div class="glass podium-step podium-1 p-5 relative flex flex-col justify-end">
-                <div class="absolute -top-5 left-1/2 -translate-x-1/2 w-10 h-10 rounded-2xl bg-gradient-to-br from-pink-brand to-blue-brand grid place-items-center shadow-card">
-                  <i data-lucide="crown" class="w-5 h-5"></i>
-                </div>
-                <div class="flex items-center gap-3">
-                  <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-pink-brand to-blue-brand grid place-items-center"><i data-lucide="trophy" class="w-5 h-5"></i></div>
-                  <div>
-                    <div class="text-sm text-white/60">#1</div>
-                    <div class="font-semibold truncate" id="p1-name">—</div>
-                  </div>
-                </div>
+              <div class="glass podium-step podium-1 p-5 relative flex flex-col items-center justify-end text-center">
+                <img src="crown.png" alt="profile" class="podium-avatar mb-2">
+                <div class="text-sm text-white/60">#1</div>
+                <div class="font-semibold truncate" id="p1-name">—</div>
                 <div class="mt-3 text-sm text-white/70" id="p1-wager">$0</div>
                 <div class="mt-1 text-xs text-white/50">Prize <span id="p1-prize">$0</span></div>
               </div>
             </div>
             <!-- 3rd -->
             <div class="podium-col">
-              <div class="glass podium-step podium-3 p-4 flex flex-col justify-end">
-                <div class="flex items-center gap-3">
-                  <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-purple to-indigo grid place-items-center"><i data-lucide="medal" class="w-5 h-5"></i></div>
-                  <div>
-                    <div class="text-sm text-white/60">#3</div>
-                    <div class="font-semibold truncate" id="p3-name">—</div>
-                  </div>
-                </div>
+              <div class="glass podium-step podium-3 p-4 flex flex-col items-center justify-end text-center">
+                <img src="crown.png" alt="profile" class="podium-avatar mb-2">
+                <div class="text-sm text-white/60">#3</div>
+                <div class="font-semibold truncate" id="p3-name">—</div>
                 <div class="mt-3 text-sm text-white/70" id="p3-wager">$0</div>
                 <div class="mt-1 text-xs text-white/50">Prize <span id="p3-prize">$0</span></div>
               </div>
@@ -458,7 +462,7 @@
           row.innerHTML = `
             <div class="text-white/70 font-semibold">#${e.rank}</div>
             <div class="flex items-center gap-3">
-              <div class="w-8 h-8 rounded-xl bg-white/10 grid place-items-center"><i data-lucide="user" class="w-4 h-4"></i></div>
+              <img src="crown.png" alt="profile" class="row-avatar">
               <div class="truncate">${e.username}</div>
             </div>
             <div class="text-white/80">${formatMoney(e.total_wagered)}</div>


### PR DESCRIPTION
## Summary
- Add 3D-inspired styling for podium elements including shadows and gradients
- Use `crown.png` as the avatar for top ranks and list entries
- Display crown avatars for each leaderboard user

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a24376351c83329cc1a2be092ae39d